### PR TITLE
JCN 313 actualizar package

### DIFF
--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -1,6 +1,6 @@
 name: Coverage Status
 
-on: ["push", "pull_request"]
+on: ["push"]
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - SLS-API-List, method `customSortableFields` and `customAvailableFilters`
 
 ### Changed
-- Every API Module, validates Bucket in `validate()` method. Now if fails finsh with `status-code: 400`
+- Every API Module, validates Bucket in `validate()` method. Now If validation fails it sets status code `400`
 - SLS-API-List changed `shouldAddUrl` not check `type: "image"` anymore, now only returns `false` as default (must overwrite to change to `true`)
 
 ## [2.0.0] - 2020-09-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Every API Module, method `postValidateHook`
+- SLS-API-Relation, method `postSaveHook` and `format`
+- SLS-API-Delete, method `postDeleteHook`
+- SLS-API-List and SLS-API-Get, method `formatUrl` and `formatFileData`
+- SLS-API-List, method `customSortableFields` and `customAvailableFilters`
+
+### Changed
+- Every API Module, validates Bucket in `validate()` method. Now if fails finsh with `status-code: 400`
+- SLS-API-List changed `shouldAddUrl` not check `type: "image"` anymore, now only returns `false` as default (must overwrite to change to `true`)
 
 ## [2.0.0] - 2020-09-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ This module has only one Hook:
 
 > This Class extends from [@janiscommerce/api](https://www.npmjs.com/package/@janiscommerce/api)
 
-**IMPORTANT**, this API must be requested after making the upload to S3 Bucket.
+:warning: **IMPORTANT**, this API must be requested after making the upload to S3 Bucket.
 
 ### API Example
 
@@ -598,6 +598,7 @@ This module has only one Hook:
 ### API Example
 
 ```js
+// in src/api/item/file/get.js
 'use strict';
 
 const { SlsApiFileGet } = require('@janiscommerce/sls-api-upload');

--- a/README.md
+++ b/README.md
@@ -625,8 +625,8 @@ get bucket() {
 ### Format
 
 The File-Document can be formatted in the same way as in the [SLS-API-List](#SlsApiFileList) using
-* [formatFileData](#formatFileData(fileData))
-* [formatUrl](formatUrl(path))
+* [formatFileData](#formatfiledatafiledata)
+* [formatUrl](formaturlpath)
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package contains several modules to handle upload files, list it, or delete
 npm install @janiscommerce/sls-api-upload
 ```
 
-## :bookmark: Content
+## Content
 
 In this package, you can found several modules to create APIs to manage files, uploads, delete or get them.
 
@@ -26,7 +26,7 @@ In this package, you can found several modules to create APIs to manage files, u
 
 Every Module can be customize.
 
-## :mag: Common Validation
+## Common Validation
 
 Some APIs Modules offers some custom validation for specfics features such as file size, or file type, but everyone has a common validation hook.
 
@@ -46,7 +46,7 @@ class MyApiUpload extends SlsApiUpload {
 };
 ```
 
-## :footprints: BaseFileModel
+## BaseFileModel
 
 <details>
 	<summary>This Module allows you to create a Model for file-data document.</summary>
@@ -124,7 +124,7 @@ static get fields() {
 </details>
 
 
-## :outbox_tray: SlsApiUpload
+## SlsApiUpload
 
 <details>
 	<summary>This Module allows you to create an API to get a valid pre-signed URL and headers in order to upload a file to a S3 Bucket.</summary>
@@ -272,7 +272,7 @@ This module has only one Hook:
 
 </details>
 
-## :inbox_tray: SlsApiFileRelation
+## SlsApiFileRelation
 
 <details>
 	<summary>This Module allows you to create an API to create a Document with the file data in the Database Collection.</summary>
@@ -466,7 +466,7 @@ And final document saved in database would be:
 
 </details>
 
-## :open_book: SlsApiFileList
+## SlsApiFileList
 
 <details>
 	<summary>This Module allows you to create an API to List file-data documents.</summary>
@@ -584,7 +584,7 @@ This module has only one Hook:
 
 </details>
 
-## :page_with_curl: SlsApiFileGet
+## SlsApiFileGet
 
 <details>
 	<summary>This Module allows you to create an API to get a single file-data document.</summary>
@@ -636,7 +636,7 @@ This module has only one Hook:
 
 </details>
 
-## :scissors: SlsApiFileDelete
+## SlsApiFileDelete
 
 <details>
 	<summary>This Module allows you to create an API to delete a file from S3 Bucket and Database Collection.</summary>

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ static get fields() {
 <details>
 	<summary>This Module allows you to create an API to get a valid pre-signed URL and headers in order to upload a file to a S3 Bucket.</summary>
 
+> This Class extends from [@janiscommerce/api](https://www.npmjs.com/package/@janiscommerce/api)
+
 ### API Example
 
 ```js
@@ -275,7 +277,9 @@ This module has only one Hook:
 <details>
 	<summary>This Module allows you to create an API to create a Document with the file data in the Database Collection.</summary>
 
-> **IMPORTANT**, this API must be requested after making the upload to S3 Bucket.
+> This Class extends from [@janiscommerce/api](https://www.npmjs.com/package/@janiscommerce/api)
+
+**IMPORTANT**, this API must be requested after making the upload to S3 Bucket.
 
 ### API Example
 
@@ -467,7 +471,7 @@ And final document saved in database would be:
 <details>
 	<summary>This Module allows you to create an API to List file-data documents.</summary>
 
-> This API extends from [@janiscommerce/api-list](https://www.npmjs.com/package/@janiscommerce/api-list), so has the some properties.
+> This API extends from [@janiscommerce/api-list](https://www.npmjs.com/package/@janiscommerce/api-list)
 
 ### API Example
 
@@ -636,6 +640,8 @@ This module has only one Hook:
 
 <details>
 	<summary>This Module allows you to create an API to delete a file from S3 Bucket and Database Collection.</summary>
+
+> This Class extends from [@janiscommerce/api](https://www.npmjs.com/package/@janiscommerce/api)
 
 ### API Example
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package contains several modules to handle upload files, list it, or delete
 npm install @janiscommerce/sls-api-upload
 ```
 
-## Content
+## :bookmark: Content
 
 In this package, you can found several modules to create APIs to manage files, uploads, delete or get them.
 
@@ -26,7 +26,7 @@ In this package, you can found several modules to create APIs to manage files, u
 
 Every Module can be customize.
 
-## Common Validation
+## :mag: Common Validation
 
 Some APIs Modules offers some custom validation for specfics features such as file size, or file type, but everyone has a common validation hook.
 
@@ -46,7 +46,7 @@ class MyApiUpload extends SlsApiUpload {
 };
 ```
 
-## BaseFileModel
+## :footprints: BaseFileModel
 
 <details>
 	<summary>This Module allows you to create a Model for file-data document.</summary>
@@ -124,7 +124,7 @@ static get fields() {
 </details>
 
 
-## SlsApiUpload
+## :outbox_tray: SlsApiUpload
 
 <details>
 	<summary>This Module allows you to create an API to get a valid pre-signed URL and headers in order to upload a file to a S3 Bucket.</summary>
@@ -272,7 +272,7 @@ This module has only one Hook:
 
 </details>
 
-## SlsApiFileRelation
+## :inbox_tray: SlsApiFileRelation
 
 <details>
 	<summary>This Module allows you to create an API to create a Document with the file data in the Database Collection.</summary>
@@ -466,7 +466,7 @@ And final document saved in database would be:
 
 </details>
 
-## SlsApiFileList
+## :open_book: SlsApiFileList
 
 <details>
 	<summary>This Module allows you to create an API to List file-data documents.</summary>
@@ -584,7 +584,7 @@ This module has only one Hook:
 
 </details>
 
-## SlsApiFileGet
+## :page_with_curl: SlsApiFileGet
 
 <details>
 	<summary>This Module allows you to create an API to get a single file-data document.</summary>
@@ -636,7 +636,7 @@ This module has only one Hook:
 
 </details>
 
-## SlsApiFileDelete
+## :scissors: SlsApiFileDelete
 
 <details>
 	<summary>This Module allows you to create an API to delete a file from S3 Bucket and Database Collection.</summary>

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ static get fields() {
 
 > This Class extends from [@janiscommerce/api](https://www.npmjs.com/package/@janiscommerce/api)
 
+:warning: **IMPORTANT**: When you get the response you can use it to make the request with the file.
+
+If you want to see more about it:
+* [AWS preSigned URL](https://docs.aws.amazon.com/AmazonS3/latest/dev/PresignedUrlUploadObject.html)
+* [Upload an Image using Postman and S3 preSigned URL](https://medium.com/@lakshmanLD/upload-file-to-s3-using-lambda-the-pre-signed-url-way-158f074cda6c)
+
 ### API Example
 
 ```js
@@ -188,8 +194,6 @@ module.exports = class MyApiUpload extends SlsApiUpload {
 	}
 }
 ```
-
-When you get this response you can use it to make the request with the file.
 
 ### Getters
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ The following getters can be used to customize and validate your BaseFileModel.
 
 #### static get table()
 
-*Optional* | *Default="files"*
+*Optional*
+
+*Default*: `"files"`
 
 This is used to indicate the name of the files table/collection
 
@@ -93,7 +95,20 @@ static get table() {
 
 #### static get fields()
 
-*Optional* | *Default={ id: true, path: true, size: true, name: true, type: true, dateCreated: true }*
+*Optional*
+
+*Default*:
+
+```js
+{
+	id: true,
+	path: true,
+	size: true,
+	name: true,
+	type: true,
+	dateCreated: true
+}
+```
 
 This is used to indicate the fields of the files table/collection
 
@@ -193,7 +208,9 @@ get bucket() {
 
 #### get path()
 
-*Optional* | *Default=""*
+*Optional*
+
+*Default*: `""`
 
 This is used to indicate the path where the file should be saved
 
@@ -205,7 +222,9 @@ get path() {
 
 #### get availableTypes()
 
-*Optional* | *Default=[]*
+*Optional*
+
+*Default*: `[]`
 
 This is used to indicate the accepted file types to be uploaded. If you not define them, all types will be valid. Example:
 
@@ -217,7 +236,9 @@ get availableTypes() {
 
 #### get expiration()
 
-*Optional* | *Default=60*
+*Optional*
+
+*Default*: `60`
 
 This is used to indicate the expiration time in seconds of the generated URL
 
@@ -229,7 +250,9 @@ get expiration() {
 
 #### get sizeRange()
 
-*Optional* | *Default=[1,10485760] // 1B to 10MB*
+*Optional*
+
+*Default*: `[1,10485760] // 1B to 10MB`
 
 This is used to indicate the valid file size range to be uploaded
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ static get fields() {
 
 If you want to see more about it:
 * [AWS preSigned URL](https://docs.aws.amazon.com/AmazonS3/latest/dev/PresignedUrlUploadObject.html)
-* [Upload an Image using Postman and S3 preSigned URL](https://medium.com/@lakshmanLD/upload-file-to-s3-using-lambda-the-pre-signed-url-way-158f074cda6c)
+* [Upload an Image using Postman and S3 preSigned URL](https://medium.com/@lakshmanLD/upload-file-to-s3-using-lambda-the-pre-signed-url-way-158f074cda6c), see Step 2.
 
 ### API Example
 

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ get bucket() {
 
 The File-Document can be formatted in the same way as in the [SLS-API-List](#SlsApiFileList) using
 * [formatFileData](#formatfiledatafiledata)
-* [formatUrl](formaturlpath)
+* [formatUrl](#formaturlpath)
 
 ### Hooks
 

--- a/lib/helper/format-url.js
+++ b/lib/helper/format-url.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const S3 = require('@janiscommerce/s3');
+
+module.exports = async (path, name, bucket, ErrorClass) => {
+
+	try {
+
+		const url = await S3.getSignedUrl('getObject', {
+			Bucket: bucket,
+			Key: path,
+			ResponseContentDisposition: `attachment; filename="${name}"`
+		});
+
+		return url;
+
+	} catch(error) {
+
+		if(error.statusCode !== 404)
+			throw new ErrorClass(error);
+
+		return null;
+	}
+};

--- a/lib/sls-api-file-delete.js
+++ b/lib/sls-api-file-delete.js
@@ -7,6 +7,7 @@ const SlsApiFileDeleteError = require('./sls-api-file-delete-error');
 module.exports = class SlsApiFileDelete extends API {
 
 	async validate() {
+
 		if(!this.model)
 			throw new SlsApiFileDeleteError(SlsApiFileDeleteError.messages.MODEL_NOT_DEFINED);
 
@@ -24,10 +25,19 @@ module.exports = class SlsApiFileDelete extends API {
 
 		if(typeof this.bucket !== 'string')
 			throw new SlsApiFileDeleteError(SlsApiFileDeleteError.messages.BUCKET_NOT_STRING);
+
+		if(this.postValidateHook) {
+			try {
+				await this.postValidateHook();
+			} catch(error) {
+				throw new SlsApiFileDeleteError(error);
+			}
+		}
 	}
 
 
 	async process() {
+
 		const [entityId, fileId] = this.pathParameters;
 
 		this.modelInstance = this.session.getSessionInstance(this.model);
@@ -49,6 +59,8 @@ module.exports = class SlsApiFileDelete extends API {
 			if(error.statusCode !== 404)
 				throw new SlsApiFileDeleteError(error);
 		}
-	}
 
+		if(this.postDeleteHook)
+			return this.postDeleteHook(record);
+	}
 };

--- a/lib/sls-api-file-get.js
+++ b/lib/sls-api-file-get.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const S3 = require('@janiscommerce/s3');
 const { ApiGet } = require('@janiscommerce/api-get');
 const SlsApiFileGetError = require('./sls-api-file-get-error');
+
+const formatUrlDefault = require('./helper/format-url');
 
 module.exports = class SlsApiFileGet extends ApiGet {
 
@@ -41,24 +42,7 @@ module.exports = class SlsApiFileGet extends ApiGet {
 		return { ...recordFormatted, url };
 	}
 
-	async formatUrl(path, name) {
-
-		try {
-
-			const url = await S3.getSignedUrl('getObject', {
-				Bucket: this.bucket,
-				Key: path,
-				ResponseContentDisposition: `attachment; filename="${name}"`
-			});
-
-			return url;
-
-		} catch(error) {
-
-			if(error.statusCode !== 404)
-				throw new SlsApiFileGetError(error);
-
-			return null;
-		}
+	formatUrl(path, name) {
+		return formatUrlDefault(path, name, this.bucket, SlsApiFileGetError);
 	}
 };

--- a/lib/sls-api-file-get.js
+++ b/lib/sls-api-file-get.js
@@ -6,7 +6,23 @@ const SlsApiFileGetError = require('./sls-api-file-get-error');
 
 module.exports = class SlsApiFileGet extends ApiGet {
 
+	async validate() {
+
+		await super.validate();
+
+		this.validateBucket();
+
+		if(this.postValidateHook) {
+			try {
+				await this.postValidateHook();
+			} catch(error) {
+				throw new SlsApiFileGetError(error);
+			}
+		}
+	}
+
 	validateBucket() {
+
 		if(!this.bucket)
 			throw new SlsApiFileGetError(SlsApiFileGetError.messages.BUCKET_NOT_DEFINED);
 
@@ -15,24 +31,34 @@ module.exports = class SlsApiFileGet extends ApiGet {
 	}
 
 	async format(record) {
-		this.validateBucket();
 
 		const { path, ...currentRecord } = record;
 
-		let url = null;
+		const url = await this.formatUrl(path, record.name);
 
-		try {
-			url = await S3.getSignedUrl('getObject', {
-				Bucket: this.bucket,
-				Key: record.path,
-				ResponseContentDisposition: `attachment; filename="${currentRecord.name}"`
-			});
-		} catch(error) {
-			if(error.statusCode !== 404)
-				throw new SlsApiFileGetError(error);
-		}
+		const recordFormatted = this.formatRecord ? await this.formatRecord(currentRecord) : currentRecord;
 
-		return { ...currentRecord, url };
+		return { ...recordFormatted, url };
 	}
 
+	async formatUrl(path, name) {
+
+		try {
+
+			const url = await S3.getSignedUrl('getObject', {
+				Bucket: this.bucket,
+				Key: path,
+				ResponseContentDisposition: `attachment; filename="${name}"`
+			});
+
+			return url;
+
+		} catch(error) {
+
+			if(error.statusCode !== 404)
+				throw new SlsApiFileGetError(error);
+
+			return null;
+		}
+	}
 };

--- a/lib/sls-api-file-get.js
+++ b/lib/sls-api-file-get.js
@@ -36,7 +36,7 @@ module.exports = class SlsApiFileGet extends ApiGet {
 
 		const url = await this.formatUrl(path, record.name);
 
-		const recordFormatted = this.formatRecord ? await this.formatRecord(currentRecord) : currentRecord;
+		const recordFormatted = this.formatFileData ? await this.formatFileData(currentRecord) : currentRecord;
 
 		return { ...recordFormatted, url };
 	}

--- a/lib/sls-api-file-list.js
+++ b/lib/sls-api-file-list.js
@@ -1,7 +1,12 @@
 'use strict';
 
 const S3 = require('@janiscommerce/s3');
-const { ApiListData } = require('@janiscommerce/api-list');
+const {
+	ApiListData,
+	FilterMappers: {
+		dateMapper
+	}
+} = require('@janiscommerce/api-list');
 const SlsApiFileListError = require('./sls-api-file-list-error');
 
 module.exports = class FileListApi extends ApiListData {
@@ -29,7 +34,7 @@ module.exports = class FileListApi extends ApiListData {
 			'name',
 			{
 				name: 'dateCreated',
-				valueMapper: date => new Date(date)
+				valueMapper: dateMapper
 			},
 			...this.customAvailableFilters
 		];

--- a/lib/sls-api-file-list.js
+++ b/lib/sls-api-file-list.js
@@ -12,6 +12,10 @@ const SlsApiFileListError = require('./sls-api-file-list-error');
 module.exports = class FileListApi extends ApiListData {
 
 	get sortableFields() {
+
+		if(!Array.isArray(this.customSortableFields))
+			throw new SlsApiFileListError(SlsApiFileListError.messages.INVALID_SORTABLE_FIELDS);
+
 		return [
 			'id',
 			'name',
@@ -29,6 +33,10 @@ module.exports = class FileListApi extends ApiListData {
 	}
 
 	get availableFilters() {
+
+		if(!Array.isArray(this.customAvailableFilters))
+			throw new SlsApiFileListError(SlsApiFileListError.messages.INVALID_FILTERS_FIELDS);
+
 		return [
 			'id',
 			'name',

--- a/lib/sls-api-file-list.js
+++ b/lib/sls-api-file-list.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const S3 = require('@janiscommerce/s3');
 const {
 	ApiListData,
 	FilterMappers: {
@@ -8,6 +7,8 @@ const {
 	}
 } = require('@janiscommerce/api-list');
 const SlsApiFileListError = require('./sls-api-file-list-error');
+
+const formatUrlDefault = require('./helper/format-url');
 
 module.exports = class FileListApi extends ApiListData {
 
@@ -101,24 +102,7 @@ module.exports = class FileListApi extends ApiListData {
 		return { ...fileDataFormatted, url };
 	}
 
-	async formatUrl(path, name) {
-
-		try {
-
-			const url = await S3.getSignedUrl('getObject', {
-				Bucket: this.bucket,
-				Key: path,
-				ResponseContentDisposition: `attachment; filename="${name}"`
-			});
-
-			return url;
-
-		} catch(error) {
-
-			if(error.statusCode !== 404)
-				throw new SlsApiFileListError(error);
-
-			return null;
-		}
+	formatUrl(path, name) {
+		return formatUrlDefault(path, name, this.bucket, SlsApiFileListError);
 	}
 };

--- a/lib/sls-api-file-list.js
+++ b/lib/sls-api-file-list.js
@@ -86,18 +86,19 @@ module.exports = class FileListApi extends ApiListData {
 	}
 
 	formatRows(files) {
+		return Promise.all(files.map(file => this.formatFile(file)));
+	}
 
-		return Promise.all(files.map(async ({ path, ...file }) => {
+	async formatFile({ path, ...file }) {
 
-			const fileDataFormatted = this.formatFileData ? await this.formatFileData(file) : file;
+		const fileDataFormatted = this.formatFileData ? await this.formatFileData(file) : file;
 
-			if(!this.shouldAddUrl)
-				return fileDataFormatted;
+		if(!this.shouldAddUrl)
+			return fileDataFormatted;
 
-			const url = await this.formatUrl(path, file.name);
+		const url = await this.formatUrl(path, file.name);
 
-			return { ...fileDataFormatted, url };
-		}));
+		return { ...fileDataFormatted, url };
 	}
 
 	async formatUrl(path, name) {

--- a/lib/sls-api-file-list.js
+++ b/lib/sls-api-file-list.js
@@ -10,8 +10,17 @@ module.exports = class FileListApi extends ApiListData {
 		return [
 			'id',
 			'name',
-			'dateCreated'
+			'dateCreated',
+			...this.customSortableFields
 		];
+	}
+
+	/**
+	 * Custom Sortable Fields
+	 * @returns {Array<String>}
+	 */
+	get customSortableFields() {
+		return [];
 	}
 
 	get availableFilters() {
@@ -21,51 +30,81 @@ module.exports = class FileListApi extends ApiListData {
 			{
 				name: 'dateCreated',
 				valueMapper: date => new Date(date)
-			}
+			},
+			...this.customAvailableFilters
 		];
 	}
 
-	formatRows(files) {
-
-		return Promise.all(files.map(async ({ path, ...file }) => {
-
-			if(!this.shouldAddUrl(file))
-				return file;
-
-			this.validateBucket();
-
-			let url = null;
-
-			try {
-				url = await S3.getSignedUrl('getObject', {
-					Bucket: this.bucket,
-					Key: path,
-					ResponseContentDisposition: `attachment; filename="${file.name}"`
-				});
-			} catch(error) {
-				if(error.statusCode !== 404)
-					throw new SlsApiFileListError(error);
-			}
-
-			return { ...file, url };
-		}));
+	/**
+	 * Custom AvailableFilters
+	 * @returns {Array<string|object>} filters type object
+	 */
+	get customAvailableFilters() {
+		return [];
 	}
 
-	shouldAddUrl(file) {
-		return file.type === 'image';
+	get shouldAddUrl() {
+		return false;
+	}
+
+	async validate() {
+
+		await super.validate();
+
+		if(this.shouldAddUrl)
+			this.validateBucket();
+
+		if(this.postValidateHook) {
+			try {
+				await this.postValidateHook();
+			} catch(error) {
+				throw new SlsApiFileListError(error);
+			}
+		}
 	}
 
 	validateBucket() {
-
-		if(this.isValidBucket)
-			return;
 
 		if(!this.bucket)
 			throw new SlsApiFileListError(SlsApiFileListError.messages.BUCKET_NOT_DEFINED);
 
 		if(typeof this.bucket !== 'string')
 			throw new SlsApiFileListError(SlsApiFileListError.messages.BUCKET_NOT_STRING);
+	}
 
-		this.isValidBucket = true;
+	formatRows(files) {
+
+		return Promise.all(files.map(async ({ path, ...file }) => {
+
+			const fileDataFormatted = this.formatFileData ? await this.formatFileData(file) : file;
+
+			if(!this.shouldAddUrl)
+				return fileDataFormatted;
+
+			const url = await this.formatUrl(path, file.name);
+
+			return { ...fileDataFormatted, url };
+		}));
+	}
+
+	async formatUrl(path, name) {
+
+		try {
+
+			const url = await S3.getSignedUrl('getObject', {
+				Bucket: this.bucket,
+				Key: path,
+				ResponseContentDisposition: `attachment; filename="${name}"`
+			});
+
+			return url;
+
+		} catch(error) {
+
+			if(error.statusCode !== 404)
+				throw new SlsApiFileListError(error);
+
+			return null;
+		}
 	}
 };

--- a/lib/sls-api-file-relation-error.js
+++ b/lib/sls-api-file-relation-error.js
@@ -9,7 +9,9 @@ module.exports = class SlsApiFileRelationError extends Error {
 			ENTITY_ID_FIELD_NOT_DEFINED: 'EntityIdField not defined',
 			ENTITY_ID_FIELD_NOT_STRING: 'EntityIdField should be return a string',
 			MODEL_NOT_DEFINED: 'Model not defined',
-			MODEL_IS_NOT_MODEL_CLASS: 'Model is not a Model Class'
+			MODEL_IS_NOT_MODEL_CLASS: 'Model is not a Model Class',
+			INVALID_SORTABLE_FIELDS: 'Invalid Custom Sortable Fields. Must be an Array.',
+			INVALID_FILTERS_FIELDS: 'Invalid Custom Available Filters. Must be an Array.'
 		};
 	}
 

--- a/lib/sls-api-file-relation.js
+++ b/lib/sls-api-file-relation.js
@@ -78,9 +78,9 @@ module.exports = class SlsApiFileRelation extends API {
 		if(typeof this.bucket !== 'string')
 			throw new SlsApiFileRelationError(SlsApiFileRelationError.messages.BUCKET_NOT_STRING);
 
-		if(this.postValidateHoook) {
+		if(this.postValidateHook) {
 			try {
-				await this.postValidateHoook();
+				await this.postValidateHook();
 			} catch(error) {
 				throw new SlsApiFileRelationError(error);
 			}

--- a/lib/sls-api-file-relation.js
+++ b/lib/sls-api-file-relation.js
@@ -6,6 +6,13 @@ const SlsApiFileRelationError = require('./sls-api-file-relation-error');
 
 module.exports = class SlsApiFileRelation extends API {
 
+	get entityId() {
+
+		const [entityId] = this.pathParameters;
+
+		return entityId;
+	}
+
 	/**
 	 * Method for take a simplified type for save type field
 	 * @param {string} mimeType
@@ -51,7 +58,8 @@ module.exports = class SlsApiFileRelation extends API {
 	}
 
 
-	validate() {
+	async validate() {
+
 		if(!this.model)
 			throw new SlsApiFileRelationError(SlsApiFileRelationError.messages.MODEL_NOT_DEFINED);
 
@@ -69,37 +77,52 @@ module.exports = class SlsApiFileRelation extends API {
 
 		if(typeof this.bucket !== 'string')
 			throw new SlsApiFileRelationError(SlsApiFileRelationError.messages.BUCKET_NOT_STRING);
+
+		if(this.postValidateHoook) {
+			try {
+				await this.postValidateHoook();
+			} catch(error) {
+				throw new SlsApiFileRelationError(error);
+			}
+		}
 	}
 
-
 	async process() {
-		const [entityId] = this.pathParameters;
-
-		const { fileName: name, fileSource: path, ...additionalData } = this.data;
 
 		const modelInstance = this.session.getSessionInstance(this.model);
 
 		try {
 
-			const { ContentLength, ContentType } = await S3.headObject({ Bucket: this.bucket, Key: path });
+			const dataFormatted = await this.formatFileData();
 
-			const id = await modelInstance.insert({
-				[this.entityIdField]: entityId,
-				name,
-				path,
-				mimeType: ContentType,
-				type: this.constructor.getSimplifiedType(ContentType),
-				size: ContentLength,
-				...additionalData
-			});
+			const id = await modelInstance.insert(dataFormatted);
 
-			this
-				.setCode(201)
-				.setBody({ id });
+			if(this.postSaveHook)
+				await this.postSaveHook(id, dataFormatted);
+
+			this.setCode(201).setBody({ id });
 
 		} catch(error) {
 			throw new SlsApiFileRelationError(error);
 		}
 	}
 
+	async formatFileData() {
+
+		const { fileName: name, fileSource: path, ...additionalData } = this.data;
+
+		const { ContentLength, ContentType } = await S3.headObject({ Bucket: this.bucket, Key: path });
+
+		const additionalDataFormatted = this.format ? await this.format(additionalData) : additionalData;
+
+		return {
+			[this.entityIdField]: this.entityId,
+			name,
+			path,
+			mimeType: ContentType,
+			type: this.constructor.getSimplifiedType(ContentType),
+			size: ContentLength,
+			...additionalDataFormatted
+		};
+	}
 };

--- a/lib/sls-api-file-relation.js
+++ b/lib/sls-api-file-relation.js
@@ -6,13 +6,6 @@ const SlsApiFileRelationError = require('./sls-api-file-relation-error');
 
 module.exports = class SlsApiFileRelation extends API {
 
-	get entityId() {
-
-		const [entityId] = this.pathParameters;
-
-		return entityId;
-	}
-
 	/**
 	 * Method for take a simplified type for save type field
 	 * @param {string} mimeType
@@ -109,6 +102,8 @@ module.exports = class SlsApiFileRelation extends API {
 
 	async formatFileData() {
 
+		const [entityId] = this.pathParameters;
+
 		const { fileName: name, fileSource: path, ...additionalData } = this.data;
 
 		const { ContentLength, ContentType } = await S3.headObject({ Bucket: this.bucket, Key: path });
@@ -116,7 +111,7 @@ module.exports = class SlsApiFileRelation extends API {
 		const additionalDataFormatted = this.format ? await this.format(additionalData) : additionalData;
 
 		return {
-			[this.entityIdField]: this.entityId,
+			[this.entityIdField]: entityId,
 			name,
 			path,
 			mimeType: ContentType,

--- a/lib/sls-api-upload.js
+++ b/lib/sls-api-upload.js
@@ -57,7 +57,7 @@ module.exports = class SlsApiUpload extends API {
 		return path;
 	}
 
-	validate() {
+	async validate() {
 		const { fileName } = this.data;
 
 		if(!this.bucket)
@@ -94,9 +94,18 @@ module.exports = class SlsApiUpload extends API {
 
 		if(typeof minSize !== 'number' || typeof maxSize !== 'number')
 			throw new SlsApiUploadError(SlsApiUploadError.messages.LENGTH_RANGE_ITEM_NOT_NUMBER);
+
+		if(this.postValidateHook) {
+			try {
+				await this.postValidateHook();
+			} catch(error) {
+				throw new SlsApiUploadError(error);
+			}
+		}
 	}
 
 	async process() {
+
 		const id = uuid();
 
 		const path = this.resolvePath();

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@janiscommerce/s3": "^1.3.0",
     "aws-sdk": "^2.749.0",
     "mime": "2.4.6",
-    "superstruct": "0.6.2",
     "uuid": "8.3.0"
   }
 }

--- a/tests/sls-api-file-delete.js
+++ b/tests/sls-api-file-delete.js
@@ -35,8 +35,23 @@ describe('SlsApiFileDelete', () => {
 		bucket: 'test'
 	});
 
+	const apiCustom = ({
+		postValidateHook = () => true,
+		postDeleteHook = () => true
+	} = {}) => class CustomApi extends defaultApiExtended {
+
+		postValidateHook() {
+			return postValidateHook();
+		}
+
+		postDeleteHook() {
+			return postDeleteHook();
+		}
+	};
+
 
 	context('Validate', () => {
+
 		APITest(apiExtendedSimple({ model: null }), [{
 			description: 'Should return 400 if model is not defined',
 			response: { code: 400, body: { message: SlsApiFileDeleteError.messages.MODEL_NOT_DEFINED } }
@@ -57,9 +72,7 @@ describe('SlsApiFileDelete', () => {
 			response: { code: 400, body: { message: SlsApiFileDeleteError.messages.ENTITY_ID_FIELD_NOT_STRING } }
 		}]);
 
-		APITest(apiExtendedSimple({
-			entityIdField: 'test'
-		}), [{
+		APITest(apiExtendedSimple({ entityIdField: 'test' }), [{
 			description: 'Should return 400 if bucket is not defined',
 			response: { code: 400, body: { message: SlsApiFileDeleteError.messages.BUCKET_NOT_DEFINED } }
 		}]);
@@ -71,90 +84,164 @@ describe('SlsApiFileDelete', () => {
 			description: 'Should return 400 if bucket is not a string',
 			response: { code: 400, body: { message: SlsApiFileDeleteError.messages.BUCKET_NOT_STRING } }
 		}]);
+
+		APITest(apiCustom({
+			postValidateHook: () => { throw new Error(); }
+		}), [{
+			description: 'Should return 400 if custom validation fails',
+			response: { code: 400 }
+		}]);
 	});
 
 	context('Process', () => {
-		APITest(defaultApiExtended, [{
-			before: sandbox => {
-				sandbox.stub(BaseModel.prototype, 'get').rejects();
-				sandbox.stub(BaseModel.prototype, 'remove');
-				sandbox.stub(S3, 'deleteObject');
+
+		APITest(defaultApiExtended, [
+			{
+				description: 'Should return 500 if fail get current file record',
+				session: true,
+				request: {
+					pathParameters: [1, 2]
+				},
+				response: { code: 500 },
+				before: sandbox => {
+					sandbox.stub(BaseModel.prototype, 'get').rejects();
+					sandbox.stub(BaseModel.prototype, 'remove');
+					sandbox.stub(S3, 'deleteObject');
+				},
+				after: (afterResponse, sandbox) => {
+					sandbox.assert.calledOnce(BaseModel.prototype.get);
+					sandbox.assert.notCalled(BaseModel.prototype.remove);
+					sandbox.assert.notCalled(S3.deleteObject);
+				}
 			},
+			{
+				description: 'Should return 500 if fail model remove',
+				session: true,
+				request: {
+					pathParameters: [1, 2]
+				},
+				response: { code: 500 },
+				before: sandbox => {
+					sandbox.stub(BaseModel.prototype, 'get').resolves([{
+						path: '/files/file.jpg'
+					}]);
+					sandbox.stub(BaseModel.prototype, 'remove').rejects();
+					sandbox.stub(S3, 'deleteObject');
+				},
+				after: (afterResponse, sandbox) => {
+					sandbox.assert.calledOnce(BaseModel.prototype.get);
+					sandbox.assert.calledOnce(BaseModel.prototype.remove);
+					sandbox.assert.notCalled(S3.deleteObject);
+				}
+			},
+			{
+				description: 'Should return 500 if fail deleteObject',
+				session: true,
+				request: {
+					pathParameters: [1, 2]
+				},
+				response: { code: 500 },
+				before: sandbox => {
+					sandbox.stub(BaseModel.prototype, 'get').resolves([{
+						path: '/files/file.jpg'
+					}]);
+					sandbox.stub(BaseModel.prototype, 'remove').resolves(1);
+					sandbox.stub(S3, 'deleteObject').rejects();
+				},
+				after: (afterResponse, sandbox) => {
+					sandbox.assert.calledOnce(BaseModel.prototype.get);
+					sandbox.assert.calledOnce(BaseModel.prototype.remove);
+					sandbox.assert.calledOnce(S3.deleteObject);
+				}
+			},
+			{
+				description: 'Should return 404 if not exists current file record',
+				session: true,
+				request: {
+					pathParameters: [1, 2]
+				},
+				response: {
+					code: 404,
+					body: { message: SlsApiFileDeleteError.messages.FILE_RECORD_NOT_FOUND }
+				},
+				before: sandbox => {
+					sandbox.stub(BaseModel.prototype, 'get').resolves([]);
+					sandbox.stub(BaseModel.prototype, 'remove');
+					sandbox.stub(S3, 'deleteObject');
+				},
+				after: (afterResponse, sandbox) => {
+					sandbox.assert.calledOnce(BaseModel.prototype.get);
+					sandbox.assert.notCalled(BaseModel.prototype.remove);
+					sandbox.assert.notCalled(S3.deleteObject);
+				}
+			},
+			{
+				description: 'Should return 200 if delete record and file correctly',
+				session: true,
+				request: {
+					pathParameters: [1, 2]
+				},
+				response: { code: 200 },
+				before: sandbox => {
+					sandbox.stub(BaseModel.prototype, 'get').resolves([{
+						path: '/files/file.jpg'
+					}]);
+					sandbox.stub(BaseModel.prototype, 'remove').resolves(1);
+					sandbox.stub(S3, 'deleteObject').resolves();
+				},
+				after: (afterResponse, sandbox) => {
+					sandbox.assert.calledWithExactly(BaseModel.prototype.get, {
+						filters: { test: 1, id: 2 }
+					});
+
+					sandbox.assert.calledWithExactly(BaseModel.prototype.remove, { id: 2 });
+
+					sandbox.assert.calledWithExactly(S3.deleteObject, {
+						Bucket: 'test',
+						Key: '/files/file.jpg'
+					});
+				}
+			},
+			{
+				description: 'Should return 200 if delete record correctly but file not exist in s3',
+				session: true,
+				request: {
+					pathParameters: [1, 2]
+				},
+				response: { code: 200 },
+				before: sandbox => {
+					sandbox.stub(BaseModel.prototype, 'get').resolves([{
+						path: '/files/file.jpg'
+					}]);
+					sandbox.stub(BaseModel.prototype, 'remove').resolves(1);
+					sandbox.stub(S3, 'deleteObject').rejects({
+						statusCode: 404
+					});
+				},
+				after: (afterResponse, sandbox) => {
+					sandbox.assert.calledWithExactly(BaseModel.prototype.get, {
+						filters: { test: 1, id: 2 }
+					});
+
+					sandbox.assert.calledWithExactly(BaseModel.prototype.remove, { id: 2 });
+
+					sandbox.assert.calledWithExactly(S3.deleteObject, {
+						Bucket: 'test',
+						Key: '/files/file.jpg'
+					});
+				}
+			}
+		]);
+	});
+
+	APITest(apiCustom(), [
+		{
+			description: 'Should return 200 if custom validation and postDeleteHooks are correct',
 			session: true,
-			description: 'Should return 500 if fail get current file record',
 			request: {
 				pathParameters: [1, 2]
 			},
-			response: { code: 500 },
-			after: (afterResponse, sandbox) => {
-				sandbox.assert.calledOnce(BaseModel.prototype.get);
-				sandbox.assert.notCalled(BaseModel.prototype.remove);
-				sandbox.assert.notCalled(S3.deleteObject);
-			}
-		}]);
-
-		APITest(defaultApiExtended, [{
-			before: sandbox => {
-				sandbox.stub(BaseModel.prototype, 'get').resolves([{
-					path: '/files/file.jpg'
-				}]);
-				sandbox.stub(BaseModel.prototype, 'remove').rejects();
-				sandbox.stub(S3, 'deleteObject');
-			},
-			session: true,
-			description: 'Should return 500 if fail model remove',
-			request: {
-				pathParameters: [1, 2]
-			},
-			response: { code: 500 },
-			after: (afterResponse, sandbox) => {
-				sandbox.assert.calledOnce(BaseModel.prototype.get);
-				sandbox.assert.calledOnce(BaseModel.prototype.remove);
-				sandbox.assert.notCalled(S3.deleteObject);
-			}
-		}]);
-
-		APITest(defaultApiExtended, [{
-			before: sandbox => {
-				sandbox.stub(BaseModel.prototype, 'get').resolves([{
-					path: '/files/file.jpg'
-				}]);
-				sandbox.stub(BaseModel.prototype, 'remove').resolves(1);
-				sandbox.stub(S3, 'deleteObject').rejects();
-			},
-			session: true,
-			description: 'Should return 500 if fail deleteObject',
-			request: {
-				pathParameters: [1, 2]
-			},
-			response: { code: 500 },
-			after: (afterResponse, sandbox) => {
-				sandbox.assert.calledOnce(BaseModel.prototype.get);
-				sandbox.assert.calledOnce(BaseModel.prototype.remove);
-				sandbox.assert.calledOnce(S3.deleteObject);
-			}
-		}]);
-
-		APITest(defaultApiExtended, [{
-			before: sandbox => {
-				sandbox.stub(BaseModel.prototype, 'get').resolves([]);
-				sandbox.stub(BaseModel.prototype, 'remove');
-				sandbox.stub(S3, 'deleteObject');
-			},
-			session: true,
-			description: 'Should return 404 if not exists current file record',
-			request: {
-				pathParameters: [1, 2]
-			},
-			response: { code: 404, body: { message: SlsApiFileDeleteError.messages.FILE_RECORD_NOT_FOUND } },
-			after: (afterResponse, sandbox) => {
-				sandbox.assert.calledOnce(BaseModel.prototype.get);
-				sandbox.assert.notCalled(BaseModel.prototype.remove);
-				sandbox.assert.notCalled(S3.deleteObject);
-			}
-		}]);
-
-		APITest(defaultApiExtended, [{
+			response: { code: 200 },
 			before: sandbox => {
 				sandbox.stub(BaseModel.prototype, 'get').resolves([{
 					path: '/files/file.jpg'
@@ -162,12 +249,6 @@ describe('SlsApiFileDelete', () => {
 				sandbox.stub(BaseModel.prototype, 'remove').resolves(1);
 				sandbox.stub(S3, 'deleteObject').resolves();
 			},
-			session: true,
-			description: 'Should return 200 if delete record and file correctly',
-			request: {
-				pathParameters: [1, 2]
-			},
-			response: { code: 200 },
 			after: (afterResponse, sandbox) => {
 				sandbox.assert.calledWithExactly(BaseModel.prototype.get, {
 					filters: { test: 1, id: 2 }
@@ -180,24 +261,26 @@ describe('SlsApiFileDelete', () => {
 					Key: '/files/file.jpg'
 				});
 			}
-		}]);
+		}
+	]);
 
-		APITest(defaultApiExtended, [{
+	APITest(apiCustom({
+		postDeleteHook: () => { throw new Error(); }
+	}), [
+		{
+			description: 'Should return 500 if postDeleteHooks fails',
+			session: true,
+			request: {
+				pathParameters: [1, 2]
+			},
+			response: { code: 500 },
 			before: sandbox => {
 				sandbox.stub(BaseModel.prototype, 'get').resolves([{
 					path: '/files/file.jpg'
 				}]);
 				sandbox.stub(BaseModel.prototype, 'remove').resolves(1);
-				sandbox.stub(S3, 'deleteObject').rejects({
-					statusCode: 404
-				});
+				sandbox.stub(S3, 'deleteObject').resolves();
 			},
-			session: true,
-			description: 'Should return 200 if delete record correctly but file not exist in s3',
-			request: {
-				pathParameters: [1, 2]
-			},
-			response: { code: 200 },
 			after: (afterResponse, sandbox) => {
 				sandbox.assert.calledWithExactly(BaseModel.prototype.get, {
 					filters: { test: 1, id: 2 }
@@ -210,6 +293,6 @@ describe('SlsApiFileDelete', () => {
 					Key: '/files/file.jpg'
 				});
 			}
-		}]);
-	});
+		}
+	]);
 });

--- a/tests/sls-api-file-list.js
+++ b/tests/sls-api-file-list.js
@@ -127,6 +127,42 @@ describe('File List Api', () => {
 	context('When Should not add url', () => {
 
 		APITest(apiCustom({
+			customSortableFields: 'order'
+		}), [
+			{
+				description: 'Should return 400 if custom Sortable Fiels is invalid',
+				session: true,
+				response: {
+					code: 400
+				},
+				before: sandbox => {
+					sandbox.stub(BaseModel.prototype, 'get');
+				},
+				after: (response, sandbox) => {
+					sandbox.assert.notCalled(BaseModel.prototype.get);
+				}
+			}
+		]);
+
+		APITest(apiCustom({
+			customAvailableFilters: 'order'
+		}), [
+			{
+				description: 'Should return 400 if custom Available Filters is invalid',
+				session: true,
+				response: {
+					code: 400
+				},
+				before: sandbox => {
+					sandbox.stub(BaseModel.prototype, 'get');
+				},
+				after: (response, sandbox) => {
+					sandbox.assert.notCalled(BaseModel.prototype.get);
+				}
+			}
+		]);
+
+		APITest(apiCustom({
 			postValidateHook: () => { throw new Error(); }
 		}), [
 			{

--- a/tests/sls-api-file-relation.js
+++ b/tests/sls-api-file-relation.js
@@ -13,26 +13,22 @@ describe('SlsApiRelation', () => {
 		bucket,
 		customFieldsStruct,
 		model = BaseModel
-	} = {}) => {
-		class API extends SlsApiFileRelation {
-			get entityIdField() {
-				return entityIdField;
-			}
-
-			get bucket() {
-				return bucket;
-			}
-
-			get model() {
-				return model;
-			}
-
-			get customFieldsStruct() {
-				return customFieldsStruct || super.customFieldsStruct;
-			}
+	} = {}) => class API extends SlsApiFileRelation {
+		get entityIdField() {
+			return entityIdField;
 		}
 
-		return API;
+		get bucket() {
+			return bucket;
+		}
+
+		get model() {
+			return model;
+		}
+
+		get customFieldsStruct() {
+			return customFieldsStruct || super.customFieldsStruct;
+		}
 	};
 
 	const defaultApiExtended = apiExtendedSimple({
@@ -40,9 +36,29 @@ describe('SlsApiRelation', () => {
 		bucket: 'test'
 	});
 
+	const apiCustom = ({
+		postValidateHook = () => true,
+		postSaveHook = () => true,
+		format = () => true
+	}) => class CustomApi extends defaultApiExtended {
+
+		postValidateHook() {
+			return postValidateHook();
+		}
+
+		postSaveHook() {
+			return postSaveHook();
+		}
+
+		format(additonalData) {
+			return format(additonalData);
+		}
+	};
+
 	const defaultRequestData = { fileName: 'test.js', fileSource: 'files/test.js' };
 
 	context('Validate', () => {
+
 		APITest(apiExtendedSimple({ model: null }), [{
 			description: 'Should return 400 if model is not defined',
 			request: { data: defaultRequestData },
@@ -67,9 +83,7 @@ describe('SlsApiRelation', () => {
 			response: { code: 400, body: { message: SlsApiFileRelationError.messages.ENTITY_ID_FIELD_NOT_STRING } }
 		}]);
 
-		APITest(apiExtendedSimple({
-			entityIdField: 'test'
-		}), [{
+		APITest(apiExtendedSimple({ entityIdField: 'test' }), [{
 			description: 'Should return 400 if bucket is not defined',
 			request: { data: defaultRequestData },
 			response: { code: 400, body: { message: SlsApiFileRelationError.messages.BUCKET_NOT_DEFINED } }
@@ -84,42 +98,6 @@ describe('SlsApiRelation', () => {
 			response: { code: 400, body: { message: SlsApiFileRelationError.messages.BUCKET_NOT_STRING } }
 		}]);
 
-		APITest(defaultApiExtended, [{
-			description: 'Should return 400 if not pass body',
-			request: {},
-			response: { code: 400 }
-		}]);
-
-		APITest(defaultApiExtended, [{
-			description: 'Should return 400 if not pass fileName in body',
-			request: { data: {} },
-			response: { code: 400 }
-		}]);
-
-		APITest(defaultApiExtended, [{
-			description: 'Should return 400 if not pass filename string',
-			request: { data: { fileName: 132 } },
-			response: { code: 400 }
-		}]);
-
-		APITest(defaultApiExtended, [{
-			description: 'Should return 400 if not pass fileSource in body',
-			request: { data: { fileName: 'test.js' } },
-			response: { code: 400 }
-		}]);
-
-		APITest(defaultApiExtended, [{
-			description: 'Should return 400 if not pass fileSource string',
-			request: { data: { fileName: 'test.js', fileSource: 132 } },
-			response: { code: 400 }
-		}]);
-
-		APITest(defaultApiExtended, [{
-			description: 'Should return 400 if not pass custom fields in body',
-			request: { data: { fileName: 'test.js', fileSource: 'files/test.js', type: 'asdasd' } },
-			response: { code: 400 }
-		}]);
-
 		APITest(apiExtendedSimple({
 			entityIdField: 'test',
 			bucket: 'test',
@@ -129,50 +107,137 @@ describe('SlsApiRelation', () => {
 			request: { data: { fileName: 'test.js', fileSource: 'files/test.js', type: 132 } },
 			response: { code: 400 }
 		}]);
+
+		APITest(defaultApiExtended, [
+			{
+				description: 'Should return 400 if not pass body',
+				request: {},
+				response: { code: 400 }
+			},
+			{
+				description: 'Should return 400 if not pass fileName in body',
+				request: { data: {} },
+				response: { code: 400 }
+			},
+			{
+				description: 'Should return 400 if not pass filename string',
+				request: { data: { fileName: 132 } },
+				response: { code: 400 }
+			},
+			{
+				description: 'Should return 400 if not pass fileSource in body',
+				request: { data: { fileName: 'test.js' } },
+				response: { code: 400 }
+			},
+			{
+				description: 'Should return 400 if not pass fileSource string',
+				request: { data: { fileName: 'test.js', fileSource: 132 } },
+				response: { code: 400 }
+			},
+			{
+				description: 'Should return 400 if not pass custom fields in body',
+				request: { data: { fileName: 'test.js', fileSource: 'files/test.js', type: 'asdasd' } },
+				response: { code: 400 }
+			}
+		]);
+
+		APITest(apiCustom({
+			postValidateHook: () => { throw new Error('Fails Validate'); }
+		}), [{
+			description: 'Should return 400 if not pass custom validation',
+			request: { data: { fileName: 'test.js', fileSource: 'files/test.js', type: 'asdasd' } },
+			response: { code: 400 }
+		}]);
 	});
 
 	context('Process', () => {
-		APITest(defaultApiExtended, [{
-			before: sandbox => {
-				sandbox.stub(S3, 'headObject').rejects();
-				sandbox.stub(BaseModel.prototype, 'insert');
+
+		APITest(defaultApiExtended, [
+			{
+				description: 'Should return 500 if fail headObject',
+				session: true,
+				request: {
+					data: { fileName: 'test.png', fileSource: 'files/test.png' },
+					pathParameters: [1]
+				},
+				response: { code: 500 },
+				before: sandbox => {
+					sandbox.stub(S3, 'headObject').rejects();
+					sandbox.stub(BaseModel.prototype, 'insert');
+				},
+				after: (afterResponse, sandbox) => {
+					sandbox.assert.calledOnce(S3.headObject);
+					sandbox.assert.notCalled(BaseModel.prototype.insert);
+				}
 			},
+			{
+				description: 'Should return 500 if fail model insert',
+				session: true,
+				request: {
+					data: { fileName: 'test.png', fileSource: 'files/test.png' },
+					pathParameters: [1]
+				},
+				response: { code: 500 },
+				before: sandbox => {
+					sandbox.stub(S3, 'headObject').resolves({
+						ContentType: 'image/png',
+						ContentLength: 10000
+					});
+					sandbox.stub(BaseModel.prototype, 'insert').rejects();
+				},
+				after: (afterResponse, sandbox) => {
+					sandbox.assert.calledOnce(BaseModel.prototype.insert);
+					sandbox.assert.calledOnce(S3.headObject);
+				}
+			},
+			{
+				description: 'Should return 200 with valid data',
+				session: true,
+				request: {
+					data: { fileName: 'test.png', fileSource: 'files/test.png' },
+					pathParameters: [1]
+				},
+				response: { code: 201, body: { id: 12345 } },
+				before: sandbox => {
+					sandbox.stub(S3, 'headObject').resolves({
+						ContentType: 'image/png',
+						ContentLength: 10000
+					});
+					sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
+				},
+				after: (afterResponse, sandbox) => {
+					sandbox.assert.calledWithExactly(BaseModel.prototype.insert, {
+						test: 1,
+						path: 'files/test.png',
+						name: 'test.png',
+						mimeType: 'image/png',
+						type: 'image',
+						size: 10000
+					});
+				}
+			}
+		]);
+
+		APITest(apiExtendedSimple({
+			entityIdField: 'test',
+			bucket: 'test',
+			customFieldsStruct: {
+				description: 'string',
+				order: 'number'
+			}
+		}), [{
+			description: 'Should return 200 with valid data and custom fields struct',
 			session: true,
-			description: 'Should return 500 if fail headObject',
 			request: {
-				data: { fileName: 'test.png', fileSource: 'files/test.png' },
+				data: {
+					fileName: 'test.png',
+					fileSource: 'files/test.png',
+					description: 'test description',
+					order: 1
+				},
 				pathParameters: [1]
 			},
-			response: { code: 500 },
-			after: (afterResponse, sandbox) => {
-				sandbox.assert.calledOnce(S3.headObject);
-				sandbox.assert.notCalled(BaseModel.prototype.insert);
-			}
-		}]);
-
-
-		APITest(defaultApiExtended, [{
-			before: sandbox => {
-				sandbox.stub(S3, 'headObject').resolves({
-					ContentType: 'image/png',
-					ContentLength: 10000
-				});
-				sandbox.stub(BaseModel.prototype, 'insert').rejects();
-			},
-			session: true,
-			description: 'Should return 500 if fail model insert',
-			request: {
-				data: { fileName: 'test.png', fileSource: 'files/test.png' },
-				pathParameters: [1]
-			},
-			response: { code: 500 },
-			after: (afterResponse, sandbox) => {
-				sandbox.assert.calledOnce(BaseModel.prototype.insert);
-				sandbox.assert.calledOnce(S3.headObject);
-			}
-		}]);
-
-		APITest(defaultApiExtended, [{
+			response: { code: 201, body: { id: 12345 } },
 			before: sandbox => {
 				sandbox.stub(S3, 'headObject').resolves({
 					ContentType: 'image/png',
@@ -180,13 +245,37 @@ describe('SlsApiRelation', () => {
 				});
 				sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
 			},
+			after: (afterResponse, sandbox) => {
+				sandbox.assert.calledWithExactly(BaseModel.prototype.insert, {
+					test: 1,
+					path: 'files/test.png',
+					name: 'test.png',
+					mimeType: 'image/png',
+					type: 'image',
+					size: 10000,
+					description: 'test description',
+					order: 1
+				});
+			}
+		}]);
+
+		APITest(apiCustom({
+			postValidateHook: () => true
+		}), [{
+			description: 'Should return 200 with custom validation and post-save-hook',
 			session: true,
-			description: 'Should return 200 with valid data',
 			request: {
 				data: { fileName: 'test.png', fileSource: 'files/test.png' },
 				pathParameters: [1]
 			},
 			response: { code: 201, body: { id: 12345 } },
+			before: sandbox => {
+				sandbox.stub(S3, 'headObject').resolves({
+					ContentType: 'image/png',
+					ContentLength: 10000
+				});
+				sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
+			},
 			after: (afterResponse, sandbox) => {
 				sandbox.assert.calledWithExactly(BaseModel.prototype.insert, {
 					test: 1,
@@ -199,14 +288,16 @@ describe('SlsApiRelation', () => {
 			}
 		}]);
 
-		APITest(apiExtendedSimple({
-			entityIdField: 'test',
-			bucket: 'test',
-			customFieldsStruct: {
-				description: 'string',
-				order: 'number'
-			}
+		APITest(apiCustom({
+			postSaveHook: () => { throw new Error('Fails'); }
 		}), [{
+			description: 'Should return 500 if fails in post-save-hook',
+			session: true,
+			request: {
+				data: { fileName: 'test.png', fileSource: 'files/test.png' },
+				pathParameters: [1]
+			},
+			response: { code: 500 },
 			before: sandbox => {
 				sandbox.stub(S3, 'headObject').resolves({
 					ContentType: 'image/png',
@@ -214,18 +305,57 @@ describe('SlsApiRelation', () => {
 				});
 				sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
 			},
+			after: (afterResponse, sandbox) => {
+				sandbox.assert.calledWithExactly(BaseModel.prototype.insert, {
+					test: 1,
+					path: 'files/test.png',
+					name: 'test.png',
+					mimeType: 'image/png',
+					type: 'image',
+					size: 10000
+				});
+			}
+		}]);
+
+		APITest(apiCustom({
+			format: () => { throw new Error('Fails'); }
+		}), [{
+			description: 'Should return 500 and no save if fails in format',
 			session: true,
-			description: 'Should return 200 with valid data and custom fields struct',
 			request: {
-				data: {
-					fileName: 'test.png',
-					fileSource: 'files/test.png',
-					description: 'test description',
-					order: 1
-				},
+				data: { fileName: 'test.png', fileSource: 'files/test.png' },
+				pathParameters: [1]
+			},
+			response: { code: 500 },
+			before: sandbox => {
+				sandbox.stub(S3, 'headObject').resolves({
+					ContentType: 'image/png',
+					ContentLength: 10000
+				});
+				sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
+			},
+			after: (afterResponse, sandbox) => {
+				sandbox.assert.notCalled(BaseModel.prototype.insert);
+			}
+		}]);
+
+		APITest(apiCustom({
+			format: () => ({ order: 1 })
+		}), [{
+			description: 'Should return 200 and add a custom field',
+			session: true,
+			request: {
+				data: { fileName: 'test.png', fileSource: 'files/test.png' },
 				pathParameters: [1]
 			},
 			response: { code: 201, body: { id: 12345 } },
+			before: sandbox => {
+				sandbox.stub(S3, 'headObject').resolves({
+					ContentType: 'image/png',
+					ContentLength: 10000
+				});
+				sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
+			},
 			after: (afterResponse, sandbox) => {
 				sandbox.assert.calledWithExactly(BaseModel.prototype.insert, {
 					test: 1,
@@ -234,7 +364,6 @@ describe('SlsApiRelation', () => {
 					mimeType: 'image/png',
 					type: 'image',
 					size: 10000,
-					description: 'test description',
 					order: 1
 				});
 			}
@@ -291,6 +420,13 @@ describe('SlsApiRelation', () => {
 		}];
 
 		APITest(defaultApiExtended, types.map(({ extension, type }) => ({
+			description: `Should return 200 passing diferents files types in data (${extension})`,
+			session: true,
+			request: {
+				data: { fileName: `test${extension}`, fileSource: `files/test${extension}` },
+				pathParameters: [1]
+			},
+			response: { code: 201, body: { id: 12345 } },
 			before: sandbox => {
 				sandbox.stub(S3, 'headObject').resolves({
 					ContentType: mime.getType(extension),
@@ -298,13 +434,6 @@ describe('SlsApiRelation', () => {
 				});
 				sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
 			},
-			session: true,
-			description: `Should return 200 passing diferents files types in data (${extension})`,
-			request: {
-				data: { fileName: `test${extension}`, fileSource: `files/test${extension}` },
-				pathParameters: [1]
-			},
-			response: { code: 201, body: { id: 12345 } },
 			after: (afterResponse, sandbox) => {
 				sandbox.assert.calledWithExactly(BaseModel.prototype.insert, sandbox.match({
 					type

--- a/tests/sls-api-file-relation.js
+++ b/tests/sls-api-file-relation.js
@@ -39,7 +39,7 @@ describe('SlsApiRelation', () => {
 	const apiCustom = ({
 		postValidateHook = () => true,
 		postSaveHook = () => true,
-		format = () => true
+		format = data => data
 	}) => class CustomApi extends defaultApiExtended {
 
 		postValidateHook() {
@@ -145,7 +145,10 @@ describe('SlsApiRelation', () => {
 			postValidateHook: () => { throw new Error('Fails Validate'); }
 		}), [{
 			description: 'Should return 400 if not pass custom validation',
-			request: { data: { fileName: 'test.js', fileSource: 'files/test.js', type: 'asdasd' } },
+			request: {
+				data: { fileName: 'test.png', fileSource: 'files/test.png' },
+				pathParameters: [1]
+			},
 			response: { code: 400 }
 		}]);
 	});

--- a/tests/sls-api-get.js
+++ b/tests/sls-api-get.js
@@ -62,15 +62,15 @@ describe('SlsApiFileGet', () => {
 
 	const apiCustom = ({
 		postValidateHook = () => true,
-		formatRecord = data => data
+		formatFileData = data => data
 	}) => class CustomApi extends defaultApiExtended {
 
 		postValidateHook() {
 			return postValidateHook();
 		}
 
-		formatRecord(data) {
-			return formatRecord(data);
+		formatFileData(data) {
+			return formatFileData(data);
 		}
 	};
 
@@ -227,10 +227,10 @@ describe('SlsApiFileGet', () => {
 		]);
 
 		APITest(apiCustom({
-			formatRecord: () => { throw new Error(); }
+			formatFileData: () => { throw new Error(); }
 		}), 'api/entity/1/file/2', [
 			{
-				description: 'Should return 500 if fails formatRecord',
+				description: 'Should return 500 if fails formatFileData',
 				session: true,
 				request: {
 					pathParameters: [1, 2]
@@ -251,7 +251,7 @@ describe('SlsApiFileGet', () => {
 		]);
 
 		APITest(apiCustom({
-			formatRecord: data => ({ ...data, order: 1 })
+			formatFileData: data => ({ ...data, order: 1 })
 		}), 'api/entity/1/file/2', [
 			{
 				description: 'Should return 200 with custom format adding field',


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-313

**DESCRIPCIÓN DEL REQUERIMIENTO**

Actualmente el package https://github.com/janis-commerce/sls-api-upload  permite subir un archivo a un bucket de S3, gettearlos individual y como listado, y borrarlos.

Pero no contiene hooks (como los de API-Save-Data), ni puede formatearse de manera custom y esto hace que su posibilidades de uso sean limitadas

Requerimiento:
* Crear los hooks faltantes en la API Post (Relation), es decir `postSaveHook`
* Crear los hooks de `postValidateHook`, para todos las API que lo necesiten, que sirva para chequeos extras.
* Agregar la posibilidad de tener nuevos `formats`, para poder realizar modificaciones custom a los datos de los archivos cuando se necesiten

**DESCRIPCIÓN DE LA SOLUCIÓN**
* Se desarrollaron los requerimientos solicitados.
* Se mejoró el README.
* En la API de Listado se agregan métodos para agregar filtros y ordenamiento de manera mas limpia, y se cambió la forma de agregar la URL a los objetos
* En las API de Listado y  GET, se agregaron 2 formats, uno para los datos  en general y uno especifico para la URL

Para ver correctamente renderizado el README:

https://github.com/janis-commerce/sls-api-upload/blob/JCN-313-Actualizar-package/README.md