### PR TITLE
Add expiration options when getting credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,19 @@ get entity() {
 }
 ```
 
+#### get fileExpiration()
+
+*Optional*
+
+Allows you to set a custom expiration for the file.  
+**Possible values**: `oneDay` | `tendays` | `month` | `never`
+
+```js
+get fileExpiration() {
+	return 'oneDay';
+}
+```
+
 ### Request Data
 
 This API has the following required request data:
@@ -354,6 +367,19 @@ Request data example;
 	"fileName": "image.png",
 	"fileSource": "files/images/1f368ddd-97b6-4076-ba63-9e0a71273aac.png",
 	"myRelationshipCustomField": "theValue"
+}
+```
+
+#### get fileExpiration()
+
+*Optional*
+
+Allows you to set a custom expiration for the file.  
+**Possible values**: `oneDay` | `tendays` | `month` | `never`
+
+```js
+get fileExpiration() {
+	return 'oneDay';
 }
 ```
 

--- a/lib/base-model.js
+++ b/lib/base-model.js
@@ -7,4 +7,16 @@ module.exports = class BaseFileModel extends Model {
 	static get table() {
 		return 'files';
 	}
+
+	static get indexes() {
+		return [
+			{
+				name: 'expiration',
+				key: {
+					expireAt: 1
+				},
+				expireAfterSeconds: 0
+			}
+		];
+	}
 };

--- a/lib/sls-api-file-get-credentials.js
+++ b/lib/sls-api-file-get-credentials.js
@@ -22,14 +22,6 @@ module.exports = class SlsApiFileGetCredentials extends API {
 		return credentialsStruct;
 	}
 
-	/**
-	 * Allows you to set a custom expiration for the file
-	 * Possible values: 'oneDay'|'tenDays'|'month'|'never'
-	 */
-	get fileExpiration() {
-		return undefined;
-	}
-
 	async validate() {
 
 		if(!this.entity)

--- a/lib/sls-api-file-get-credentials.js
+++ b/lib/sls-api-file-get-credentials.js
@@ -7,7 +7,7 @@ const { Invoker } = require('@janiscommerce/lambda');
 const SlsApiFileGetCredentialsError = require('./sls-api-file-get-credentials-error');
 const { isEmpty } = require('./helper/is-empty');
 
-const EXPIRATION_FILE_OPTIONS = ['oneDay', 'tenDays', 'monthly', 'never'];
+const EXPIRATION_FILE_OPTIONS = ['oneDay', 'tenDays', 'month', 'never'];
 
 const credentialsStruct = struct.partial({
 	credentialExpiration: 'positive?',
@@ -20,6 +20,14 @@ module.exports = class SlsApiFileGetCredentials extends API {
 
 	get struct() {
 		return credentialsStruct;
+	}
+
+	/**
+	 * Allows you to set a custom expiration for the file
+	 * Possible values: 'oneDay'|'tenDays'|'month'|'never'
+	 */
+	get fileExpiration() {
+		return undefined;
 	}
 
 	async validate() {
@@ -51,8 +59,11 @@ module.exports = class SlsApiFileGetCredentials extends API {
 	 */
 	async getCredentials() {
 
+		const fileExpiration = this.fileExpiration || this.data.fileExpiration;
+
 		const requestData = {
 			...this.data,
+			...fileExpiration && { fileExpiration },
 			serviceName: process.env.JANIS_SERVICE_NAME,
 			entity: this.entity
 		};

--- a/lib/sls-api-file-get-credentials.js
+++ b/lib/sls-api-file-get-credentials.js
@@ -7,8 +7,11 @@ const { Invoker } = require('@janiscommerce/lambda');
 const SlsApiFileGetCredentialsError = require('./sls-api-file-get-credentials-error');
 const { isEmpty } = require('./helper/is-empty');
 
+const EXPIRATION_FILE_OPTIONS = ['oneDay', 'tenDays', 'monthly', 'never'];
+
 const credentialsStruct = struct.partial({
-	expiration: 'positive?',
+	credentialExpiration: 'positive?',
+	fileExpiration: struct.optional(struct.enum(EXPIRATION_FILE_OPTIONS)),
 	fileNames: struct.dynamic((value, parent) => struct(parent.fileName ? struct.optional('array&!empty') : 'array&!empty')),
 	fileName: struct.dynamic((value, parent) => struct(parent.fileNames ? struct.optional('string&!empty') : 'string&!empty'))
 });

--- a/lib/sls-api-file-relation.js
+++ b/lib/sls-api-file-relation.js
@@ -9,7 +9,7 @@ const SlsApiFileRelationError = require('./sls-api-file-relation-error');
 const EXPIRATION_FILE_OPTIONS = {
 	oneDay: 1,
 	tenDays: 10,
-	monthly: 30,
+	month: 30,
 	never: 'never'
 };
 
@@ -48,6 +48,14 @@ module.exports = class SlsApiFileRelation extends API {
 	 * Custom fields Struct validation
 	 */
 	get customFieldsStruct() {
+		return undefined;
+	}
+
+	/**
+	 * Allows you to set a custom expiration for the file
+	 * Possible values: 'oneDay'|'tenDays'|'month'|'never'
+	 */
+	get expiration() {
 		return undefined;
 	}
 
@@ -123,9 +131,7 @@ module.exports = class SlsApiFileRelation extends API {
 
 		const { ContentLength, ContentType } = await this.getFileInfo(path);
 
-		const expirationOption = EXPIRATION_FILE_OPTIONS[expiration] || EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE];
-
-		const expirationDate = this.getExpirationDate(expirationOption);
+		const expirationDate = this.getExpirationDate(expiration);
 
 		const additionalDataFormatted = this.format ? await this.format(additionalData) : additionalData;
 
@@ -156,9 +162,12 @@ module.exports = class SlsApiFileRelation extends API {
 		return payload[path];
 	}
 
-	getExpirationDate(expirationOption) {
+	getExpirationDate(expiration) {
 
-		if(expirationOption === 'never')
+		// eslint-disable-next-line max-len
+		const expirationOption = EXPIRATION_FILE_OPTIONS[this.expiration] || EXPIRATION_FILE_OPTIONS[expiration] || EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE];
+
+		if(expirationOption === EXPIRATION_FILE_OPTIONS.never)
 			return;
 
 		const expireDate = new Date();

--- a/lib/sls-api-file-relation.js
+++ b/lib/sls-api-file-relation.js
@@ -2,8 +2,20 @@
 
 const { API } = require('@janiscommerce/api');
 const { Invoker } = require('@janiscommerce/lambda');
+const { struct } = require('@janiscommerce/superstruct');
 
 const SlsApiFileRelationError = require('./sls-api-file-relation-error');
+
+// const EXPIRATION_FILE_OPTIONS = ['oneDay', 'tenDays', 'monthly', 'never'];
+
+const EXPIRATION_FILE_OPTIONS = {
+	oneDay: 1,
+	tenDays: 10,
+	monthly: 30,
+	never: 'never'
+};
+
+const DEFAULT_EXPIRATION_FILE = 'tenDays';
 
 module.exports = class SlsApiFileRelation extends API {
 
@@ -49,6 +61,7 @@ module.exports = class SlsApiFileRelation extends API {
 		return {
 			fileName: 'string',
 			fileSource: 'string',
+			expiration: struct.optional(struct.enum(Object.keys(EXPIRATION_FILE_OPTIONS))),
 			...this.customFieldsStruct
 		};
 	}
@@ -108,9 +121,13 @@ module.exports = class SlsApiFileRelation extends API {
 
 		const [entityId] = this.pathParameters;
 
-		const { fileName: name, fileSource: path, ...additionalData } = this.data;
+		const { fileName: name, fileSource: path, expiration, ...additionalData } = this.data;
 
 		const { ContentLength, ContentType } = await this.getFileInfo(path);
+
+		const expirationOption = EXPIRATION_FILE_OPTIONS[expiration] || EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE];
+
+		const expirationDate = this.getExpirationDate(expirationOption);
 
 		const additionalDataFormatted = this.format ? await this.format(additionalData) : additionalData;
 
@@ -121,6 +138,7 @@ module.exports = class SlsApiFileRelation extends API {
 			mimeType: ContentType || null,
 			type: this.constructor.getSimplifiedType(ContentType),
 			size: ContentLength || null,
+			...expirationDate && { expireAt: expirationDate },
 			...additionalDataFormatted
 		};
 	}
@@ -138,5 +156,17 @@ module.exports = class SlsApiFileRelation extends API {
 			return {};
 
 		return payload[path];
+	}
+
+	getExpirationDate(expirationOption) {
+
+		if(expirationOption === 'never')
+			return;
+
+		const expireDate = new Date();
+		expireDate.setDate(expireDate.getDate() + expirationOption);
+
+		return expireDate;
+
 	}
 };

--- a/lib/sls-api-file-relation.js
+++ b/lib/sls-api-file-relation.js
@@ -13,7 +13,7 @@ const EXPIRATION_FILE_OPTIONS = {
 	never: 'never'
 };
 
-const DEFAULT_EXPIRATION_FILE = 'tenDays';
+const DEFAULT_EXPIRATION_FILE = EXPIRATION_FILE_OPTIONS.tenDays;
 
 module.exports = class SlsApiFileRelation extends API {
 
@@ -48,14 +48,6 @@ module.exports = class SlsApiFileRelation extends API {
 	 * Custom fields Struct validation
 	 */
 	get customFieldsStruct() {
-		return undefined;
-	}
-
-	/**
-	 * Allows you to set a custom expiration for the file
-	 * Possible values: 'oneDay'|'tenDays'|'month'|'never'
-	 */
-	get fileExpiration() {
 		return undefined;
 	}
 
@@ -165,7 +157,7 @@ module.exports = class SlsApiFileRelation extends API {
 	getExpirationDate(expiration) {
 
 		// eslint-disable-next-line max-len
-		const expirationOption = EXPIRATION_FILE_OPTIONS[this.fileExpiration] || EXPIRATION_FILE_OPTIONS[expiration] || EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE];
+		const expirationOption = EXPIRATION_FILE_OPTIONS[this.fileExpiration] || EXPIRATION_FILE_OPTIONS[expiration] || DEFAULT_EXPIRATION_FILE;
 
 		if(expirationOption === EXPIRATION_FILE_OPTIONS.never)
 			return;

--- a/lib/sls-api-file-relation.js
+++ b/lib/sls-api-file-relation.js
@@ -6,8 +6,6 @@ const { struct } = require('@janiscommerce/superstruct');
 
 const SlsApiFileRelationError = require('./sls-api-file-relation-error');
 
-// const EXPIRATION_FILE_OPTIONS = ['oneDay', 'tenDays', 'monthly', 'never'];
-
 const EXPIRATION_FILE_OPTIONS = {
 	oneDay: 1,
 	tenDays: 10,

--- a/lib/sls-api-file-relation.js
+++ b/lib/sls-api-file-relation.js
@@ -55,7 +55,7 @@ module.exports = class SlsApiFileRelation extends API {
 	 * Allows you to set a custom expiration for the file
 	 * Possible values: 'oneDay'|'tenDays'|'month'|'never'
 	 */
-	get expiration() {
+	get fileExpiration() {
 		return undefined;
 	}
 
@@ -165,7 +165,7 @@ module.exports = class SlsApiFileRelation extends API {
 	getExpirationDate(expiration) {
 
 		// eslint-disable-next-line max-len
-		const expirationOption = EXPIRATION_FILE_OPTIONS[this.expiration] || EXPIRATION_FILE_OPTIONS[expiration] || EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE];
+		const expirationOption = EXPIRATION_FILE_OPTIONS[this.fileExpiration] || EXPIRATION_FILE_OPTIONS[expiration] || EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE];
 
 		if(expirationOption === EXPIRATION_FILE_OPTIONS.never)
 			return;

--- a/tests/model-builder.js
+++ b/tests/model-builder.js
@@ -10,6 +10,18 @@ describe('Base Model', () => {
 		assert.strictEqual(BaseModel.table, 'files');
 	});
 
+	it('Should return the indexes', () => {
+		assert.deepStrictEqual(BaseModel.indexes, [
+			{
+				name: 'expiration',
+				key: {
+					expireAt: 1
+				},
+				expireAfterSeconds: 0
+			}
+		]);
+	});
+
 	it('Should allow to override the table', () => {
 
 		class ModelTest extends BaseModel {

--- a/tests/sls-api-file-get-credentials.js
+++ b/tests/sls-api-file-get-credentials.js
@@ -97,13 +97,31 @@ describe('SlsApiFileGetCredentials', () => {
 				}
 			},
 			{
-				description: 'Should return 400 with invalid expiration',
+				description: 'Should return 400 with invalid credential expiration',
 				session: true,
 				request: {
 					pathParameters: [1],
 					data: {
 						fileNames: ['image.png'],
-						expiration: 'foo'
+						credentialExpiration: 'foo'
+					}
+				},
+				response: { code: 400 },
+				before: sandbox => {
+					sandbox.stub(Invoker, 'serviceSafeClientCall').resolves();
+				},
+				after: (afterResponse, sandbox) => {
+					sandbox.assert.notCalled(Invoker.serviceSafeClientCall);
+				}
+			},
+			{
+				description: 'Should return 400 with invalid file expiration',
+				session: true,
+				request: {
+					pathParameters: [1],
+					data: {
+						fileNames: ['image.png'],
+						fileExpiration: 'foo'
 					}
 				},
 				response: { code: 400 },
@@ -194,7 +212,7 @@ describe('SlsApiFileGetCredentials', () => {
 					}
 				},
 				{
-					description: 'Should return 200 when the data is wrong',
+					description: 'Should return 500 when the data is wrong',
 					session: true,
 					request: {
 						pathParameters: [1],
@@ -251,6 +269,29 @@ describe('SlsApiFileGetCredentials', () => {
 						sandbox.assert.calledWithExactly(Invoker.serviceSafeClientCall, 'storage', 'GetCredentials', 'defaultClient', {
 							...requestData,
 							fileName: 'image.png'
+						});
+					}
+				},
+				{
+					description: 'Should return 200 when request with the complete data',
+					session: true,
+					request: {
+						pathParameters: [1],
+						data: {
+							fileNames: ['image.png'],
+							credentialExpiration: '60',
+							fileExpiration: 'oneDay'
+						}
+					},
+					response: { code: 200, body: { fileNames: credentials } },
+					before: sandbox => {
+						sandbox.stub(Invoker, 'serviceSafeClientCall').resolves({ statusCode: 200, payload: { fileNames: credentials } });
+					},
+					after: (afterResponse, sandbox) => {
+						sandbox.assert.calledWithExactly(Invoker.serviceSafeClientCall, 'storage', 'GetCredentials', 'defaultClient', {
+							...requestDataMultiplesFiles,
+							credentialExpiration: '60',
+							fileExpiration: 'oneDay'
 						});
 					}
 				}

--- a/tests/sls-api-file-relation.js
+++ b/tests/sls-api-file-relation.js
@@ -9,7 +9,7 @@ const { SlsApiFileRelation, SlsApiFileRelationError } = require('../lib/index');
 const EXPIRATION_FILE_OPTIONS = {
 	oneDay: 1,
 	tenDays: 10,
-	monthly: 30,
+	month: 30,
 	never: 'never'
 };
 

--- a/tests/sls-api-file-relation.js
+++ b/tests/sls-api-file-relation.js
@@ -6,6 +6,15 @@ const { Invoker } = require('@janiscommerce/lambda');
 const BaseModel = require('../lib/base-model');
 const { SlsApiFileRelation, SlsApiFileRelationError } = require('../lib/index');
 
+const EXPIRATION_FILE_OPTIONS = {
+	oneDay: 1,
+	tenDays: 10,
+	monthly: 30,
+	never: 'never'
+};
+
+const DEFAULT_EXPIRATION_FILE = 'tenDays';
+
 describe('SlsApiRelation', () => {
 
 	const apiExtendedSimple = ({
@@ -50,6 +59,8 @@ describe('SlsApiRelation', () => {
 		}
 	};
 
+	const fakeDate = new Date();
+
 	const path = 'cdn/files/defaultClient/a87a83d3-f494-4069-a0f7-fa0894590072.png';
 	const defaultRequestData = { fileName: 'test.png', fileSource: path };
 
@@ -62,6 +73,14 @@ describe('SlsApiRelation', () => {
 			ContentType: 'image/png',
 			Metadata: {}
 		}
+	};
+
+	const buildExpirationDate = days => {
+
+		const expireDate = new Date(fakeDate);
+		expireDate.setDate(expireDate.getDate() + days);
+
+		return expireDate;
 	};
 
 	context('Validate', () => {
@@ -174,6 +193,7 @@ describe('SlsApiRelation', () => {
 				},
 				response: { code: 201 },
 				before: sandbox => {
+					sandbox.useFakeTimers(fakeDate);
 					sandbox.stub(Invoker, 'serviceSafeClientCall').resolves({});
 					sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
 				},
@@ -185,7 +205,8 @@ describe('SlsApiRelation', () => {
 						name: 'test.png',
 						mimeType: null,
 						type: 'other',
-						size: null
+						size: null,
+						expireAt: buildExpirationDate(EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE])
 					});
 				}
 			},
@@ -198,6 +219,7 @@ describe('SlsApiRelation', () => {
 				},
 				response: { code: 500 },
 				before: sandbox => {
+					sandbox.useFakeTimers(fakeDate);
 					sandbox.stub(Invoker, 'serviceSafeClientCall').resolves({ statusCode: 200, payload: fileInfo });
 					sandbox.stub(BaseModel.prototype, 'insert').rejects();
 				},
@@ -209,7 +231,8 @@ describe('SlsApiRelation', () => {
 						name: 'test.png',
 						mimeType: 'image/png',
 						type: 'image',
-						size: 10000
+						size: 10000,
+						expireAt: buildExpirationDate(EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE])
 					});
 				}
 			},
@@ -222,6 +245,7 @@ describe('SlsApiRelation', () => {
 				},
 				response: { code: 201, body: { id: 12345 } },
 				before: sandbox => {
+					sandbox.useFakeTimers(fakeDate);
 					sandbox.stub(Invoker, 'serviceSafeClientCall').resolves({ statusCode: 200, payload: fileInfo });
 					sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
 				},
@@ -233,10 +257,40 @@ describe('SlsApiRelation', () => {
 						name: 'test.png',
 						mimeType: 'image/png',
 						type: 'image',
-						size: 10000
+						size: 10000,
+						expireAt: buildExpirationDate(EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE])
 					});
 				}
-			}
+			},
+			...Object.keys(EXPIRATION_FILE_OPTIONS).map(expiration => ({
+				description: `Should return 200 and valid data when expiration ${expiration} is set`,
+				session: true,
+				request: {
+					data: {
+						...defaultRequestData,
+						expiration
+					},
+					pathParameters: [1]
+				},
+				response: { code: 201, body: { id: 12345 } },
+				before: sandbox => {
+					sandbox.useFakeTimers(fakeDate);
+					sandbox.stub(Invoker, 'serviceSafeClientCall').resolves({ statusCode: 200, payload: fileInfo });
+					sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
+				},
+				after: (afterResponse, sandbox) => {
+					sandbox.assert.calledWithExactly(Invoker.serviceSafeClientCall, 'storage', 'GetFilesInfo', 'defaultClient', { paths: [path] });
+					sandbox.assert.calledWithExactly(BaseModel.prototype.insert, {
+						test: 1,
+						path,
+						name: 'test.png',
+						mimeType: 'image/png',
+						type: 'image',
+						size: 10000,
+						...expiration !== 'never' && { expireAt: buildExpirationDate(EXPIRATION_FILE_OPTIONS[expiration]) }
+					});
+				}
+			}))
 		]);
 
 		APITest(apiExtendedSimple({
@@ -258,6 +312,7 @@ describe('SlsApiRelation', () => {
 			},
 			response: { code: 201, body: { id: 12345 } },
 			before: sandbox => {
+				sandbox.useFakeTimers(fakeDate);
 				sandbox.stub(Invoker, 'serviceSafeClientCall').resolves({ statusCode: 200, payload: fileInfo });
 				sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
 			},
@@ -270,6 +325,7 @@ describe('SlsApiRelation', () => {
 					mimeType: 'image/png',
 					type: 'image',
 					size: 10000,
+					expireAt: buildExpirationDate(EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE]),
 					description: 'test description',
 					order: 1
 				});
@@ -287,6 +343,7 @@ describe('SlsApiRelation', () => {
 			},
 			response: { code: 201, body: { id: 12345 } },
 			before: sandbox => {
+				sandbox.useFakeTimers(fakeDate);
 				sandbox.stub(Invoker, 'serviceSafeClientCall').resolves({ statusCode: 200, payload: fileInfo });
 				sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
 			},
@@ -298,7 +355,8 @@ describe('SlsApiRelation', () => {
 					name: 'test.png',
 					mimeType: 'image/png',
 					type: 'image',
-					size: 10000
+					size: 10000,
+					expireAt: buildExpirationDate(EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE])
 				});
 			}
 		}]);
@@ -314,6 +372,7 @@ describe('SlsApiRelation', () => {
 			},
 			response: { code: 500 },
 			before: sandbox => {
+				sandbox.useFakeTimers(fakeDate);
 				sandbox.stub(Invoker, 'serviceSafeClientCall').resolves({ statusCode: 200, payload: fileInfo });
 				sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
 			},
@@ -325,7 +384,8 @@ describe('SlsApiRelation', () => {
 					name: 'test.png',
 					mimeType: 'image/png',
 					type: 'image',
-					size: 10000
+					size: 10000,
+					expireAt: buildExpirationDate(EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE])
 				});
 			}
 		}]);
@@ -361,6 +421,7 @@ describe('SlsApiRelation', () => {
 			},
 			response: { code: 201, body: { id: 12345 } },
 			before: sandbox => {
+				sandbox.useFakeTimers(fakeDate);
 				sandbox.stub(Invoker, 'serviceSafeClientCall').resolves({ statusCode: 200, payload: fileInfo });
 				sandbox.stub(BaseModel.prototype, 'insert').resolves(12345);
 			},
@@ -373,6 +434,7 @@ describe('SlsApiRelation', () => {
 					mimeType: 'image/png',
 					type: 'image',
 					size: 10000,
+					expireAt: buildExpirationDate(EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE]),
 					order: 1
 				});
 			}
@@ -406,6 +468,7 @@ describe('SlsApiRelation', () => {
 			},
 			response: { code: 201, body: { id: 12345 } },
 			before: sandbox => {
+				sandbox.useFakeTimers(fakeDate);
 				sandbox.stub(Invoker, 'serviceSafeClientCall').resolves({
 					statusCode: 200,
 					payload: {
@@ -427,7 +490,8 @@ describe('SlsApiRelation', () => {
 					name: `test${extension}`,
 					mimeType: ContentType,
 					type,
-					size: 10000
+					size: 10000,
+					expireAt: buildExpirationDate(EXPIRATION_FILE_OPTIONS[DEFAULT_EXPIRATION_FILE])
 				});
 			}
 		})));


### PR DESCRIPTION
Links

[Tarea](https://janiscommerce.atlassian.net/browse/JSS-6) / [Subtarea](https://janiscommerce.atlassian.net/browse/JSS-10)

**Descripción:** 

Como se explica en https://janiscommerce.atlassian.net/browse/JSS-6 , se agregó una propiedad para determinar el LifeCycle de cada archivo. Hay que incorporar esta property en el  https://github.com/janis-commerce/sls-api-upload#slsapiupload al momento de getear las credenciales para que al llamar la lambda en Storage este dato persista.

Para la eliminación del registro según la expiración en S3:

En  sls-api-file-relation.js la API recibirá de manera opcional una opción de expiración idéntica a la descripta en  sls-api-file-get-credentials.js : 'oneDay' , 'tenDays', 'monthly', 'never'.  El valor por defecto es 'tenDays'

Esta deducirá el tiempo de expiración, desde ese momento más el plazo señalado por la opción. La fecha resultante será guardada como expireAt al momento de insertar el registro en la base de datos

Se decidió incorporar en el modelo base del package la eliminación del archivo al alcanzar la fecha determinada en expireAt,  en los casos que esta esté configurada

**Análisis funcional:**

Debido a los cambios en la lambda en janis-storage , las modificación a realizar son:

En la API sls-api-file-get-credentials.js:

Se añade la property: fileExpiration  → string

Los valores que acepta son: 'oneDay' , 'tenDays', 'monthly', 'never'

El valor por defecto es 'tenDays'

Se modifica el nombre de la propiedad expiration -> credentialExpiration para evitar confusiones

Se añade un getter fileExpiration en la api que será el primer valor a considerar al momento de setear el valor de expiración

Esto mismo se va a realizar en la API de sls-api-file-relation.js, con el getter expiration

Para setrar la expiración, la prioridad será;

Si existe el getter, usarlo

sino buscar en el parametro

sino default

Para la eliminación del registro según la expiración en S3:

En  sls-api-file-relation.js la API recibirá de manera opcional una opción de expiración idéntica a la descripta en  sls-api-file-get-credentials.js : 'oneDay' , 'tenDays', 'monthly', 'never'.  El valor por defecto es 'tenDays'

Esta deducirá el tiempo de expiración, desde ese momento más el plazo señalado por la opción. La fecha resultante será guardada como expireAt al momento de insertar el registro en la base de datos

Para la eliminación del archivo según expireAt:

Agregar un índice en el modelo baseFile en  para que expire en la fecha que indica esa propiedad 
{ "expireAt": 1 }, { expireAfterSeconds: 0 }