### PR TITLE
JCN-434 arreglar sls api upload propiedad key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `SlsApiUpload` used correctly `createPresignedPost` function
 
 ## [2.1.5-sls3] - 2023-06-08
 ### Changed

--- a/lib/sls-api-upload.js
+++ b/lib/sls-api-upload.js
@@ -120,7 +120,8 @@ module.exports = class SlsApiUpload extends API {
 			Bucket: this.bucket,
 			Expires: this.expiration,
 			Conditions: [['content-length-range', minSize, maxSize]],
-			Fields: { 'Content-Type': this.fileType, key }
+			Fields: { 'Content-Type': this.fileType },
+			Key: key
 		};
 
 		try {

--- a/tests/sls-api-upload-test.js
+++ b/tests/sls-api-upload-test.js
@@ -206,9 +206,7 @@ describe('SlsApiUpload', () => {
 				response: { code: 200 },
 				after: (afterResponse, sandbox) => {
 					sandbox.assert.calledWithMatch(S3.createPresignedPost, {
-						Fields: {
-							key: globalSandbox.match(new RegExp(`^${uuidRgx}`))
-						}
+						Key: globalSandbox.match(new RegExp(`^${uuidRgx}`))
 					});
 				}
 			},
@@ -273,9 +271,7 @@ describe('SlsApiUpload', () => {
 				response: { code: 200 },
 				after: (afterResponse, sandbox) => {
 					sandbox.assert.calledWithMatch(S3.createPresignedPost, {
-						Fields: {
-							key: globalSandbox.match(new RegExp(`^files/${uuidRgx}`))
-						}
+						Key: globalSandbox.match(new RegExp(`^files/${uuidRgx}`))
 					});
 				}
 			}
@@ -299,9 +295,7 @@ describe('SlsApiUpload', () => {
 			response: { code: 200 },
 			after: (afterResponse, sandbox) => {
 				sandbox.assert.calledWithMatch(S3.createPresignedPost, {
-					Fields: {
-						key: globalSandbox.match(new RegExp(`^files/${uuidRgx}`))
-					}
+					Key: globalSandbox.match(new RegExp(`^files/${uuidRgx}`))
 				});
 			}
 		}]);
@@ -312,9 +306,7 @@ describe('SlsApiUpload', () => {
 			response: { code: 200 },
 			after: (afterResponse, sandbox) => {
 				sandbox.assert.calledWithMatch(S3.createPresignedPost, {
-					Fields: {
-						key: globalSandbox.match(new RegExp(`^files/images/${uuidRgx}`))
-					}
+					Key: globalSandbox.match(new RegExp(`^files/images/${uuidRgx}`))
 				});
 			}
 		}]);


### PR DESCRIPTION
LINK AL TICKET
https://janiscommerce.atlassian.net/browse/JCN-433

DESCRIPCIÓN DEL REQUERIMIENTO
En el package de [GitHub - janis-commerce/sls-api-upload](https://github.com/janis-commerce/sls-api-upload) en la versión 2.1.5 que usa el SDK v3 de AWS, pero no usa el MS de Storage, tiene un problema con  SlsApiUpload y no se puede subir archivos normalmente.

A raiz del cambio del SDK al usar createPresignedPost cambia donde va la key, mientras que en versiones anteriores va dentro de Fields , en la nueva va fuera en Key.

Se necesita modificar esto.

DESCRIPCIÓN DE LA SOLUCIÓN
Se arreglo SlsApiUpload para el uso correcto del createPresignedPost.

> INFO: Se necesita que se publique el package en una versión de uso exclusivo